### PR TITLE
Removes unneeded timeout loop.

### DIFF
--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -16,16 +16,7 @@
 
       $('#country').change(function() {
         if($(this).val() !== '') {
-          var timeOut;
-
           $.get('/geo_locations/states_for/'+$(this).val());
-
-          //This is the most awful thing I have one in a while...
-          clearTimeout(timeOut);
-          timeOut = setTimeout(function() {
-            $("#analysis_geo_location_id").trigger("chosen:updated");
-          }, 400);
-
         } else {
           $("#state-selection").addClass("hidden");
         }

--- a/app/views/geo_locations/states_for.js.erb
+++ b/app/views/geo_locations/states_for.js.erb
@@ -1,2 +1,5 @@
-$("#analysis_geo_location_id").html("<%= escape_javascript(options_from_collection_for_select(@geo_locations, :id, :state)) %>");
-$("#state-selection").removeClass("hidden");
+$(function() {
+  $("#analysis_geo_location_id").html("<%= escape_javascript(options_from_collection_for_select(@geo_locations, :id, :state)) %>");
+  $("#analysis_geo_location_id").trigger("chosen:updated");
+  $("#state-selection").removeClass("hidden");
+});


### PR DESCRIPTION
The states update is being done with Rails unobtrusive javascrit (ujs).
So after it fetch the states it goes to render the js view that is in `app/views/geo_locations/states_for.js.erb`, so the chosen's trigger can be added right after the content of the select list is added. So we don't need that timeout loop.