### PR TITLE
rice and dolomite slides for rice path with label and checkbox

### DIFF
--- a/app/views/analyses/_rice.html.erb
+++ b/app/views/analyses/_rice.html.erb
@@ -46,8 +46,8 @@
     <p class="text -questions">
       <span>
         Do you apply lime?
-        <input type="checkbox" id="lime-rice">
-        <label for="lime-rice"></label>
+        <input type="checkbox" id="limeRice">
+        <label for="limeRice"></label>
       </span>
       <span>
         <%= f.text_field :lime_amount, class: '-input-small' %>
@@ -55,8 +55,8 @@
       </span>
       <span>
         Do you apply dolomite?
-        <input type="checkbox" id="dolomite-rice">
-        <label for="dolomite-rice"></label>
+        <input type="checkbox" id="dolomiteRice">
+        <label for="dolomiteRice"></label>
       </span>
       <span>
         <%= f.text_field :dolomite_amount, class: '-input-small' %>
@@ -73,8 +73,8 @@
     <p class="text -questions">
       <span>
         Do you apply agrochemicals </br> including fertilizers, pesticides, or herbicides?
-        <input type="checkbox" id="agrochemical">
-        <label for="agrochemical"></label>
+        <input type="checkbox" id="agrochemicalRice">
+        <label for="agrochemicalRice"></label>
       </span>
       <span>
         <%= f.text_field :agrochemical_amount, class: '-input-small' %>

--- a/app/views/analyses/_rice.html.erb
+++ b/app/views/analyses/_rice.html.erb
@@ -46,7 +46,8 @@
     <p class="text -questions">
       <span>
         Do you apply lime?
-        <input type="checkbox">
+        <input type="checkbox" id="lime-rice">
+        <label for="lime-rice"></label>
       </span>
       <span>
         <%= f.text_field :lime_amount, class: '-input-small' %>
@@ -54,7 +55,8 @@
       </span>
       <span>
         Do you apply dolomite?
-        <input type="checkbox">
+        <input type="checkbox" id="dolomite-rice">
+        <label for="dolomite-rice"></label>
       </span>
       <span>
         <%= f.text_field :dolomite_amount, class: '-input-small' %>
@@ -71,7 +73,8 @@
     <p class="text -questions">
       <span>
         Do you apply agrochemicals </br> including fertilizers, pesticides, or herbicides?
-        <input type="checkbox">
+        <input type="checkbox" id="agrochemical">
+        <label for="agrochemical"></label>
       </span>
       <span>
         <%= f.text_field :agrochemical_amount, class: '-input-small' %>


### PR DESCRIPTION
In order to have label-checkbox association working, we need id to be unique. That means we can not have the slide for dolomite and lime duplicate in both paths. 

I changed the id to have that working, but it might not be very convenient for rails, 

Can you have a look, @simaob ?

Thanks! 