### PR TITLE
Feature/dynamic fields

### DIFF
--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -21,6 +21,8 @@
       new App.View.Selectors({el: '#mapSelectors'});
 
       this.addSelectLib();
+      this.addFields();
+      this.removeFields();
     },
 
     show: function(params) {
@@ -67,6 +69,24 @@
       $('select').select2({
         theme: "default",
         minimumResultsForSearch: -1
+      });
+    },
+
+    addFields: function() {
+      $(document).on('click', '.add_fields', function(event) {
+        var regexp, time;
+        time = new Date().getTime();
+        regexp = new RegExp($(this).data('id'), 'g');
+        $(this).before($(this).data('fields').replace(regexp, time));
+        return event.preventDefault();
+      });
+    },
+
+    removeFields: function() {
+      $(document).on('click', '.remove_fields', function(event) {
+        $(this).prev('input[type=hidden]').val('1');
+        $(this).closest('.form-inputs').hide();
+        return event.preventDefault();
       });
     }
 

--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -85,7 +85,7 @@
     removeFields: function() {
       $(document).on('click', '.remove_fields', function(event) {
         $(this).prev('input[type=hidden]').val('1');
-        $(this).closest('.form-inputs').hide();
+        $(this).closest('div').hide();
         return event.preventDefault();
       });
     }

--- a/app/helpers/analyses_helper.rb
+++ b/app/helpers/analyses_helper.rb
@@ -45,5 +45,18 @@ module AnalysesHelper
     end
   end
 
-
+  def link_to_add_fields(name, f, association, upper_classes=nil, bottom_classes=nil)
+    new_object = f.object.send(association).klass.new
+    id = new_object.object_id
+    fields = f.fields_for(association, new_object, child_index: id) do |builder|
+      render(association.to_s.singularize + "_fields", f: builder)
+    end
+    if upper_classes
+      fields = fields.gsub("my-upper-class-replacement", upper_classes)
+    end
+    if bottom_classes
+      fields = fields.gsub("my-bottom-class-replacement", bottom_classes)
+    end
+    link_to(name, '#', class: "add_fields", data: {id: id, fields: fields.gsub("\n", "")})
+  end
 end

--- a/app/helpers/analysis_steps_helper.rb
+++ b/app/helpers/analysis_steps_helper.rb
@@ -1,2 +1,0 @@
-module AnalysisStepsHelper
-end

--- a/app/views/analyses/_crops.html.erb
+++ b/app/views/analyses/_crops.html.erb
@@ -15,12 +15,12 @@
         <div>
           <%= builder.hidden_field :category, value: Category::FERTILIZER %>
           <span class="c-field -little">
-            <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+            <%= builder.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
             <span class="unit">kg per ha and yr</span>
           </span>
           of
           <span class="c-field -medium">
-            <%= builder.select :addition_type, select_options(Analysis::FERTILIZER_TYPES), {}, class: "-js-required" %>
+            <%= builder.select :addition_type, select_options(Analysis::FERTILIZER_TYPES) %>
           </span>
         </div>
       <% end %>
@@ -31,12 +31,12 @@
       <span>
         and
         <span class="c-field -little">
-          <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+          <%= builder.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
           <span class="unit">kg per ha and yr</span>
         </span>
         of
         <span class="c-field -medium">
-          <%= builder.select :addition_type, select_options(Analysis::MANURE_TYPES), {}, class: "-js-required" %>
+          <%= builder.select :addition_type, select_options(Analysis::MANURE_TYPES) %>
         </span>
       </span>
     <% end %>

--- a/app/views/analyses/_crops.html.erb
+++ b/app/views/analyses/_crops.html.erb
@@ -12,33 +12,35 @@
     </span>
     <span>
       <%= f.fields_for :fertilizers do |builder| %>
-        <%= builder.hidden_field :category, value: Category::FERTILIZER %>
+        <div>
+          <%= builder.hidden_field :category, value: Category::FERTILIZER %>
+          <span class="c-field -little">
+            <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+            <span class="unit">kg per ha and yr</span>
+          </span>
+          of
+          <span class="c-field -medium">
+            <%= builder.select :addition_type, select_options(Analysis::FERTILIZER_TYPES), {}, class: "-js-required" %>
+          </span>
+        </div>
+      <% end %>
+      <%= link_to_add_fields "+Add", f, :fertilizers, "-little", "-medium" %>
+    </span>
+    <%= f.fields_for :manures do |builder| %>
+      <%= builder.hidden_field :category, value: Category::MANURE %>
+      <span>
+        and
         <span class="c-field -little">
           <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
           <span class="unit">kg per ha and yr</span>
         </span>
-      of
-      <span class="c-field -medium">
-        <%= builder.select :addition_type, select_options(Analysis::FERTILIZER_TYPES), {}, class: "-js-required" %>
+        of
+        <span class="c-field -medium">
+          <%= builder.select :addition_type, select_options(Analysis::MANURE_TYPES), {}, class: "-js-required" %>
+        </span>
       </span>
-      <% end %>
-    </span>
-    <span>
-      <%= f.fields_for :manures do |builder| %>
-      <%= builder.hidden_field :category, value: Category::MANURE %>
-    </span>
-    <span>
-      and
-      <span class="c-field -little">
-        <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-        <span class="unit">kg per ha and yr</span>
-      </span>
-      of
-      <span class="c-field -medium">
-        <%= builder.select :addition_type, select_options(Analysis::MANURE_TYPES), {}, class: "-js-required" %>
-      </span>
-      <% end %>
-    </span>
+    <% end %>
+    <%= link_to_add_fields "+Add", f, :manures, "-little", "-medium" %>
   </div>
 </div>
 

--- a/app/views/analyses/_fertilizer_fields.html.erb
+++ b/app/views/analyses/_fertilizer_fields.html.erb
@@ -8,5 +8,6 @@
   <span class="c-field my-bottom-class-replacement">
     <%= f.select :addition_type, select_options(Analysis::FERTILIZER_TYPES) %>
   </span>
+  <%= f.hidden_field :_destroy %>
   <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_fertilizer_fields.html.erb
+++ b/app/views/analyses/_fertilizer_fields.html.erb
@@ -1,11 +1,12 @@
 <div>
   <%= f.hidden_field :category, value: Category::FERTILIZER %>
   <span class="c-field my-upper-class-replacement">
-    <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+    <%= f.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
     <span class="unit">kg per ha and yr</span>
   </span>
   of
   <span class="c-field my-bottom-class-replacement">
-    <%= f.select :addition_type, select_options(Analysis::FERTILIZER_TYPES), {}, class: "-js-required" %>
+    <%= f.select :addition_type, select_options(Analysis::FERTILIZER_TYPES) %>
   </span>
+  <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_fertilizer_fields.html.erb
+++ b/app/views/analyses/_fertilizer_fields.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <%= f.hidden_field :category, value: Category::FERTILIZER %>
+  <span class="c-field my-upper-class-replacement">
+    <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+    <span class="unit">kg per ha and yr</span>
+  </span>
+  of
+  <span class="c-field my-bottom-class-replacement">
+    <%= f.select :addition_type, select_options(Analysis::FERTILIZER_TYPES), {}, class: "-js-required" %>
+  </span>
+</div>

--- a/app/views/analyses/_fertilizers.html.erb
+++ b/app/views/analyses/_fertilizers.html.erb
@@ -14,6 +14,7 @@
           <%= builder.select :addition_type, select_options(Analysis::FERTILIZER_TYPES) %>
         </span>
       <% end %>
+      <%= link_to_add_fields "+Add", f, :fertilizers, "-little -light", "-little -light" %>
     </span>
     <span>
       and
@@ -28,6 +29,7 @@
           <%= builder.select :addition_type, select_options(Analysis::MANURE_TYPES) %>
         </span>
       <% end %>
+      <%= link_to_add_fields "+Add", f, :manures, "-little -light", "-little -light" %>
     </span>
 
     <span>

--- a/app/views/analyses/_fuel.html.erb
+++ b/app/views/analyses/_fuel.html.erb
@@ -6,48 +6,21 @@
     </span>
     <span>
       <%= f.fields_for :transportation_fuels do |builder| %>
-        <%= builder.hidden_field :category, value: Category::TRANSPORTATION_FUEL %>
-        <span class="c-field -little -light">
-          <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :unit, select_options(Analysis::FUEL_UNITS) %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-        </span>
-        for transportation,
+        <%= render 'transportation_fuel_fields', f: builder %>
       <% end %>
+      <%= link_to_add_fields "+Add", f, :transportation_fuels %>
     </span>
     <span>
       <%= f.fields_for :irrigation_fuels do |builder| %>
-        <span class="c-field -little -light">
-          <%= builder.hidden_field :category, value: Category::IRRIGATION_FUEL %>
-          <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :unit, select_options(Analysis::FUEL_UNITS) %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-        </span>
-        for irrigation, and
+        <%= render 'irrigation_fuel_fields', f: builder %>
       <% end %>
+      <%= link_to_add_fields "+Add", f, :irrigation_fuels %>
     </span>
     <span>
       <%= f.fields_for :fuels do |builder| %>
-        <span class="c-field -little -light">
-          <%= builder.hidden_field :category, value: Category::FUEL %>
-          <%= builder.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :unit, select_options(Analysis::FUEL_UNITS) %>
-        </span>
-        <span class="c-field -little -light">
-          <%= builder.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-        </span>
-        for other practices.
+        <%= render 'fuel_fields', f: builder %>
       <% end %>
+      <%= link_to_add_fields "+Add", f, :fuels %>
     </span>
   </div>
 </div>

--- a/app/views/analyses/_fuel_fields.html.erb
+++ b/app/views/analyses/_fuel_fields.html.erb
@@ -10,5 +10,6 @@
     <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
   </span>
   for other practices.
+  <%= f.hidden_field :_destroy %>
   <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_fuel_fields.html.erb
+++ b/app/views/analyses/_fuel_fields.html.erb
@@ -1,0 +1,11 @@
+<span class="c-field -little -light">
+  <%= f.hidden_field :category, value: Category::FUEL %>
+  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+</span>
+for other practices.

--- a/app/views/analyses/_fuel_fields.html.erb
+++ b/app/views/analyses/_fuel_fields.html.erb
@@ -1,11 +1,14 @@
-<span class="c-field -little -light">
-  <%= f.hidden_field :category, value: Category::FUEL %>
-  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-</span>
-for other practices.
+<div>
+  <span class="c-field -little -light">
+    <%= f.hidden_field :category, value: Category::FUEL %>
+    <%= f.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+  </span>
+  for other practices.
+  <%= link_to "remove", '#', class: "remove_fields" %>
+</div>

--- a/app/views/analyses/_irrigation_fuel_fields.html.erb
+++ b/app/views/analyses/_irrigation_fuel_fields.html.erb
@@ -1,0 +1,12 @@
+<span class="c-field -little -light">
+  <%= f.hidden_field :category, value: Category::IRRIGATION_FUEL %>
+  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+</span>
+for irrigation, and
+

--- a/app/views/analyses/_irrigation_fuel_fields.html.erb
+++ b/app/views/analyses/_irrigation_fuel_fields.html.erb
@@ -1,12 +1,14 @@
-<span class="c-field -little -light">
-  <%= f.hidden_field :category, value: Category::IRRIGATION_FUEL %>
-  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-</span>
-for irrigation, and
-
+<div>
+  <span class="c-field -little -light">
+    <%= f.hidden_field :category, value: Category::IRRIGATION_FUEL %>
+    <%= f.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+  </span>
+  for irrigation, and
+  <%= link_to "remove", '#', class: "remove_fields" %>
+</div>

--- a/app/views/analyses/_irrigation_fuel_fields.html.erb
+++ b/app/views/analyses/_irrigation_fuel_fields.html.erb
@@ -10,5 +10,6 @@
     <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
   </span>
   for irrigation, and
+  <%= f.hidden_field :_destroy %>
   <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_manure_fields.html.erb
+++ b/app/views/analyses/_manure_fields.html.erb
@@ -11,5 +11,6 @@
       <%= f.select :addition_type, select_options(Analysis::MANURE_TYPES) %>
     </span>
   </span>
+  <%= f.hidden_field :_destroy %>
   <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_manure_fields.html.erb
+++ b/app/views/analyses/_manure_fields.html.erb
@@ -3,12 +3,13 @@
   <span>
     and
     <span class="c-field my-upper-class-replacement">
-      <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+      <%= f.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
       <span class="unit">kg per ha and yr</span>
     </span>
     of
     <span class="c-field my-bottom-class-replacement">
-      <%= f.select :addition_type, select_options(Analysis::MANURE_TYPES), {}, class: "-js-required" %>
+      <%= f.select :addition_type, select_options(Analysis::MANURE_TYPES) %>
     </span>
   </span>
+  <%= link_to "remove", '#', class: "remove_fields" %>
 </div>

--- a/app/views/analyses/_manure_fields.html.erb
+++ b/app/views/analyses/_manure_fields.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <%= f.hidden_field :category, value: Category::MANURE %>
+  <span>
+    and
+    <span class="c-field my-upper-class-replacement">
+      <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+      <span class="unit">kg per ha and yr</span>
+    </span>
+    of
+    <span class="c-field my-bottom-class-replacement">
+      <%= f.select :addition_type, select_options(Analysis::MANURE_TYPES), {}, class: "-js-required" %>
+    </span>
+  </span>
+</div>

--- a/app/views/analyses/_transportation_fuel_fields.html.erb
+++ b/app/views/analyses/_transportation_fuel_fields.html.erb
@@ -1,0 +1,11 @@
+<%= f.hidden_field :category, value: Category::TRANSPORTATION_FUEL %>
+<span class="c-field -little -light">
+  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+</span>
+<span class="c-field -little -light">
+  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+</span>
+for transportation,

--- a/app/views/analyses/_transportation_fuel_fields.html.erb
+++ b/app/views/analyses/_transportation_fuel_fields.html.erb
@@ -1,11 +1,13 @@
-<%= f.hidden_field :category, value: Category::TRANSPORTATION_FUEL %>
-<span class="c-field -little -light">
-  <%= f.number_field :amount, class: '-right -js-required -js-numeric', autocomplete: 'off', min: '0' %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
-</span>
-<span class="c-field -little -light">
-  <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
-</span>
-for transportation,
+<div>
+  <%= f.hidden_field :category, value: Category::TRANSPORTATION_FUEL %>
+  <span class="c-field -little -light">
+    <%= f.number_field :amount, class: '-right -js-numeric', autocomplete: 'off', min: '0' %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :unit, select_options(Analysis::FUEL_UNITS) %>
+  </span>
+  <span class="c-field -little -light">
+    <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
+  </span>
+  for transportation,
+</div>

--- a/app/views/analyses/_transportation_fuel_fields.html.erb
+++ b/app/views/analyses/_transportation_fuel_fields.html.erb
@@ -10,4 +10,6 @@
     <%= f.select :addition_type, select_options(Analysis::FUEL_TYPES) %>
   </span>
   for transportation,
+  <%= f.hidden_field :_destroy %>
+  <%= link_to "remove", '#', class: "remove_fields" %>
 </div>


### PR DESCRIPTION
First take on adding multiple dynamic fields for synthetic and organic fertilizers as well as fuels.

the templates for the dynamic fields are found in:

* app/views/analyses/_fertilizer_fields.html.erb
* app/views/analyses/_manure_fields.html.erb
* app/views/analyses/_fuel_fields.html.erb
* app/views/analyses/_transportation_fuel_fields.html.erb
* app/views/analyses/_irrigation_fuel_fields.html.erb

Which are "activated" by these `<%= link_to_add_fields "+Add", f, :fertilizers, "-little", "-medium" %>` (e.g.: for fertilizers).

The javascript bit was added to the analysis controller, and the "link_to_add_fields" is a ruby helper that can be found inside `app/helpers/analyses_helper.rb`

Things ToDo still:

* style add and remove buttons;
* decide with Juan Carlos how to organize the questions so that they don't become too cluttered;
* make sure that the dropdowns use select2


Deploying early so that Juanca can have a look at it online.
