### PR TITLE
manures container

### DIFF
--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -108,6 +108,7 @@
 
         $(this).prev('input[type=hidden]').val('1');
         $(this).parents('.-js-input-wrapper').addClass('is-hidden');
+        $(this).parents('.-js-input-wrapper').find('input').removeClass('-js-required');
         return event.preventDefault();
       });
     }

--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -105,8 +105,10 @@
     removeFields: function() {
       $(document).on('click', '.-js-remove-fields', function(event) {
         event && event.preventDefault();
+
         $(this).prev('input[type=hidden]').val('1');
-        $(this).parents('.-js-input-wrapper').hide();
+        //I change this from hide to remove because that wrapper should be display flex and hide give it a display block. Please, review that this change doesn't crash anything.
+        $(this).parents('.-js-input-wrapper').remove();
         return event.preventDefault();
       });
     }

--- a/app/assets/javascripts/controllers/analysis_controller.js
+++ b/app/assets/javascripts/controllers/analysis_controller.js
@@ -107,8 +107,7 @@
         event && event.preventDefault();
 
         $(this).prev('input[type=hidden]').val('1');
-        //I change this from hide to remove because that wrapper should be display flex and hide give it a display block. Please, review that this change doesn't crash anything.
-        $(this).parents('.-js-input-wrapper').remove();
+        $(this).parents('.-js-input-wrapper').addClass('is-hidden');
         return event.preventDefault();
       });
     }

--- a/app/assets/javascripts/views/slider_view.js
+++ b/app/assets/javascripts/views/slider_view.js
@@ -262,7 +262,7 @@
         var $newFields = $target.data('fields').replace(regexp, time)
         var selectId = $($newFields).find('select').attr('id');
 
-        $('#options-container').append($newFields);
+        $('#options-container').prepend($newFields);
         $('#'+selectId).val(selectedVal);
         this.addSelectLib();
         $target.val('');

--- a/app/assets/stylesheets/components/_c-field-wrapper.scss
+++ b/app/assets/stylesheets/components/_c-field-wrapper.scss
@@ -9,6 +9,10 @@
     justify-content: space-between;
   }
 
+  &.is-hidden {
+    display: none !important;
+  }
+
   @media screen and (min-width: $screen-m) {
 
     &.-big {

--- a/app/assets/stylesheets/components/_c-slider-step.scss
+++ b/app/assets/stylesheets/components/_c-slider-step.scss
@@ -49,8 +49,11 @@
       width: 47.5%;
       margin: 25px 0 0;
     }
+  }
 
-
+  .options-container {
+    max-height: rem(300px);
+    overflow: auto;
   }
 
     // STATES

--- a/app/views/analyses/_crops.html.erb
+++ b/app/views/analyses/_crops.html.erb
@@ -57,7 +57,7 @@
       </span>
     <% end %>
 
-    <div id="options-container"></div>
+    <div id="options-container" class="options-container"></div>
 
     <span class="c-field-wrapper -medium -space-between">
       <span class="c-field -half-width">


### PR DESCRIPTION
Manures container limited height to avoid crashing layout if too many options added. 

We had a bug because we were using jquery hide() that gives a display:none. As the display for this element was forced to flex, it didn't work. I use remove() instead. 

Also, now options are prepended to the container so the last option show first to avoid it get hide with the scroll. 